### PR TITLE
Generate and attach a sha256 txt file for releases

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -72,6 +72,7 @@ echo "::endgroup::"
 tar_archive() {
 	file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
 	tar -vzcf "$file" ./*
+    sha256sum  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
 }
 echo "::group::tar: archive"
 tar_archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
             macOS ${{matrix.macos-vsn}} (64 bit).
           fail_on_unmatched_files: true
           # yamllint disable-line rule:line-length
-          files: ${{runner.temp}}/otp/macos64-${{matrix.macos-vsn}}-OTP-${{steps.configure.outputs.otp_vsn}}.tar.gz
+          files: |
+            ${{runner.temp}}/otp/macos64-${{matrix.macos-vsn}}-OTP-${{steps.configure.outputs.otp_vsn}}.tar.gz
+            ${{runner.temp}}/otp/macos64-${{matrix.macos-vsn}}-OTP-${{steps.configure.outputs.otp_vsn}}.sha256.txt
           tag_name: macos64-${{matrix.macos-vsn}}/OTP-${{steps.configure.outputs.otp_vsn}}
           target_commitish: ${{steps.update_releases.outputs.target_commitish}}


### PR DESCRIPTION
# Description

Generates a sha256 file for the tarball in a release.

Closes #2 

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
