### PR TITLE
Use shasum vs sha256sum

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -72,7 +72,7 @@ echo "::endgroup::"
 tar_archive() {
 	file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
 	tar -vzcf "$file" ./*
-    sha256sum  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
+    shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
 }
 echo "::group::tar: archive"
 tar_archive


### PR DESCRIPTION
# Description

sha256sum is not installed on GH runners, this commit adjusts the script to use the default shasum utility on mac os. 

Relates to #2 

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
