### PR TITLE
Fix release flow

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# eliminate white space differences
+3aa8d7cdbc6dc617b6855e4ee2f48b5eec149de3

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,0 @@
-# eliminate white space differences
-3aa8d7cdbc6dc617b6855e4ee2f48b5eec149de3

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -72,7 +72,7 @@ echo "::endgroup::"
 release_prepare() {
     file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
     tar -vzcf "$file" ./*
-    shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
+    shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}.sha256.txt"
 }
 echo "::group::Release: prepare"
 release_prepare

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -6,72 +6,72 @@ macos_vsn=$1
 INSTALL_DIR=$RUNNER_TEMP/otp
 
 homebrew_install() {
-	/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 }
 echo "::group::Homebrew: install"
 homebrew_install
 echo "::endgroup::"
 
 kerl_checkout() {
-	git clone https://github.com/kerl/kerl
-	cd kerl || exit
+    git clone https://github.com/kerl/kerl
+    cd kerl || exit
 }
 echo "::group::Kerl: checkout"
 kerl_checkout
 echo "::endgroup::"
 
 kerl_configure() {
-	./kerl update releases
-	MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"
-	export MAKEFLAGS
-	KERL_BUILD_DOCS="yes"
-	export KERL_BUILD_DOCS
-	echo "OpenSSL is $(openssl version)"
+    ./kerl update releases
+    MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"
+    export MAKEFLAGS
+    KERL_BUILD_DOCS="yes"
+    export KERL_BUILD_DOCS
+    echo "OpenSSL is $(openssl version)"
 }
 echo "::group::Kerl: configure"
 kerl_configure
 echo "::endgroup::"
 
 pick_otp_vsn() {
-	OTP_VSN=undefined
-	while read -r release; do
-		if git show-ref --tags --verify --quiet "refs/tags/macos64-${macos_vsn}-OTP-${release}"; then
-			continue
-		fi
-		OTP_VSN=$release
-		break
-	done < <(./kerl update releases | tail -n 70)
-	if [ "$OTP_VSN" == "undefined" ]; then
-		echo "  nothing to build. Exiting..."
-		echo "::endgroup::"
-		exit 0
-	fi
-	echo "  picked OTP $OTP_VSN"
-	export OTP_VSN
+    OTP_VSN=undefined
+    while read -r release; do
+        if git show-ref --tags --verify --quiet "refs/tags/macos64-${macos_vsn}-OTP-${release}"; then
+            continue
+        fi
+        OTP_VSN=$release
+        break
+    done < <(./kerl update releases | tail -n 70)
+    if [ "$OTP_VSN" == "undefined" ]; then
+        echo "  nothing to build. Exiting..."
+        echo "::endgroup::"
+        exit 0
+    fi
+    echo "  picked OTP $OTP_VSN"
+    export OTP_VSN
 }
 echo "::group::Erlang/OTP: pick version to build"
 pick_otp_vsn
 echo "::endgroup::"
 
 kerl_build_install() {
-	KERL_DEBUG=true ./kerl build-install "$OTP_VSN" "$OTP_VSN" "$INSTALL_DIR"
+    KERL_DEBUG=true ./kerl build-install "$OTP_VSN" "$OTP_VSN" "$INSTALL_DIR"
 }
 echo "::group::Kerl: build-install"
 kerl_build_install
 echo "::endgroup::"
 
 kerl_test() {
-	cd "$INSTALL_DIR" || exit
-	./bin/erl -s crypto -s init stop
-	./bin/erl_call
+    cd "$INSTALL_DIR" || exit
+    ./bin/erl -s crypto -s init stop
+    ./bin/erl_call
 }
 echo "::group::Kerl: test build result"
 kerl_test
 echo "::endgroup::"
 
 tar_archive() {
-	file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
-	tar -vzcf "$file" ./*
+    file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
+    tar -vzcf "$file" ./*
     shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
 }
 echo "::group::tar: archive"

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -69,13 +69,13 @@ echo "::group::Kerl: test build result"
 kerl_test
 echo "::endgroup::"
 
-tar_archive() {
+release_prepare() {
     file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
     tar -vzcf "$file" ./*
     shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
 }
-echo "::group::tar: archive"
-tar_archive
+echo "::group::Release: prepare"
+release_prepare
 echo "::endgroup::"
 
 echo "otp_vsn=${OTP_VSN}" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

The main important difference in this one is:

```diff
-    shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}-sha256.txt"
+    shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}.sha256.txt"
```

Lemme know, however, where the issue is: do you prefer `.sha256` or `-sha256`?

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
