### PR TITLE
Implement "dry run" on non-main branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ name: Release
   schedule:
     - cron: "0 */2 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - "!master"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           filename_no_ext="macos64-${{matrix.macos-vsn}}-OTP-${{steps.configure.outputs.otp_vsn}}"
           ./.github/workflows/update__releases.sh "$filename_no_ext"
+        if: ${{github.ref == 'refs/heads/main'}}
 
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: Release
 
 "on":
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: 0 */2 * * *
   workflow_dispatch:
   push:
-    branches:
-      - "!main"
+    branches-ignore:
+      - main
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 
 "on":
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: "0 */2 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
   workflow_dispatch:
   push:
     branches:
-      - "!master"
+      - "!main"
 
 jobs:
   release:
@@ -53,3 +53,4 @@ jobs:
             ${{runner.temp}}/otp/macos64-${{matrix.macos-vsn}}-OTP-${{steps.configure.outputs.otp_vsn}}.sha256.txt
           tag_name: macos64-${{matrix.macos-vsn}}/OTP-${{steps.configure.outputs.otp_vsn}}
           target_commitish: ${{steps.update_releases.outputs.target_commitish}}
+        if: ${{github.ref == 'refs/heads/main'}}


### PR DESCRIPTION
# Description

If the branch is not `main` we don't do the release.

Of course, this is not perfect because the release step is the one that might fail, but since it's the last one it should be easier to reason on, given the reduced scope (in `main`).

Closes #11.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
