### PR TITLE
Add a note on checksums and _RELEASES

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -16,7 +16,7 @@ kerl_checkout() {
     git clone https://github.com/kerl/kerl
     cd kerl || exit
 }
-echo "::group::Kerl: checkout"
+echo "::group::kerl: checkout"
 kerl_checkout
 echo "::endgroup::"
 
@@ -28,7 +28,7 @@ kerl_configure() {
     export KERL_BUILD_DOCS
     echo "OpenSSL is $(openssl version)"
 }
-echo "::group::Kerl: configure"
+echo "::group::kerl: configure"
 kerl_configure
 echo "::endgroup::"
 
@@ -56,7 +56,7 @@ echo "::endgroup::"
 kerl_build_install() {
     KERL_DEBUG=true ./kerl build-install "$OTP_VSN" "$OTP_VSN" "$INSTALL_DIR"
 }
-echo "::group::Kerl: build-install"
+echo "::group::kerl: build-install"
 kerl_build_install
 echo "::endgroup::"
 
@@ -65,7 +65,7 @@ kerl_test() {
     ./bin/erl -s crypto -s init stop
     ./bin/erl_call
 }
-echo "::group::Kerl: test build result"
+echo "::group::kerl: test build result"
 kerl_test
 echo "::endgroup::"
 

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -72,7 +72,7 @@ echo "::endgroup::"
 release_prepare() {
     file="macos64-${macos_vsn}-OTP-${OTP_VSN}.tar.gz"
     tar -vzcf "$file" ./*
-    shasum -a 256  "$file" > "${macos_vsn}-OTP-${OTP_VSN}.sha256.txt"
+    shasum -a 256 "$file" > "${macos_vsn}-OTP-${OTP_VSN}.sha256.txt"
 }
 echo "::group::Release: prepare"
 release_prepare

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ File `_RELEASES` will contain the available `.tar.gz` packages, as well as the e
 <OTP-vsn> <crc32_for_tar_gz> <date_as_utc_%Y-%m-%dT%H:%M:%SZ>
 ```
 
+Finally, we also include a `.sha256.txt` in releases, for consumers to verify the origin of the
+files. To do so, run `shasum -a 256 <file>` where `<file>` is the downloaded `.tar.gz` asset,
+then compare the result of that operation to `<file>`'s `.sha256.txt` counterpart. If they're
+different feel free to open an issue in this pull request so we can help investigate further.
+
 ### GitHub images
 
 Read more about GitHub-hosted runners in the

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The images are built with documentation chunks as per `make docs DOC_TARGETS=chu
 
 ### Releases
 
-Releases are tagged as `macos-${macos_vsn}-OTP-${otp_vsn}`, and available at
+Releases are tagged as `macos-${macos_vsn}/OTP-${otp_vsn}`, and available at
 <https://github.com/jelly-beam/otp-macos/releases/> under section Assets. We aim to keep naming
 of the assets consistent as to ease use in CI pipelines.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [release]: https://github.com/jelly-beam/otp-macos/actions/workflows/release.yml
 [release-img]: https://github.com/jelly-beam/otp-macos/actions/workflows/release.yml/badge.svg
 
-`otp-macos` is a living, and up-to-date, collection of pre-compiled macOS-ready Erlang/OTP versions.
+`otp-macos` is a living, and up-to-date, collection of precompiled macOS-ready Erlang/OTP versions.
 
 It was initially created to support macOS on <https://github.com/erlef/setup-beam> builds.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Actions (11, 12, and 13, at the time of this writing).
 
 ## The build/release pipeline
 
-Using a mix of [Homebrew](https://brew.sh/) and [kerl](https://github.com/kerl/kerl), we build
-Erlang/OTP images that target macOS for the versions supported by GitHub actions (11, 12, and
-13, at the time of this writing).
+We build the Erlang/OTP images using a mix of [Homebrew](https://brew.sh/) and
+[kerl](https://github.com/kerl/kerl), as well as some 3rd party actions. For security reasons, we
+aim to stop depending on these in the future.
 
 ### Documentation chunks
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 It was initially created to support macOS on <https://github.com/erlef/setup-beam> builds.
 
 We aim to build all Erlang versions (at most one every 2 hours - for all OS versions) starting from
-Erlang/OTP 24, as per `kerl`'s listing.
+Erlang/OTP 24, as per `kerl`'s listing, and targeting macOS for the versions supported by GitHub
+Actions (11, 12, and 13, at the time of this writing).
 
 ## The build/release pipeline
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Releases are tagged as `macos-${macos_vsn}/OTP-${otp_vsn}`, and available at
 of the assets consistent as to ease use in CI pipelines.
 
 File `_RELEASES` will contain the available `.tar.gz` packages, as well as the execution of
-`crc32` on them and a date (of approximately when the build was finished).
+`crc32` on them and a date (of approximately when the build was finished), in the following format:
+
+```
+<OTP-vsn> <crc32_for_tar_gz> <date_as_utc_%Y-%m-%dT%H:%M:%SZ>
+```
 
 ### GitHub images
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ of the assets consistent as to ease use in CI pipelines.
 File `_RELEASES` will contain the available `.tar.gz` packages, as well as the execution of
 `crc32` on them and a date (of approximately when the build was finished), in the following format:
 
-```
+```plain
 <OTP-vsn> <crc32_for_tar_gz> <date_as_utc_%Y-%m-%dT%H:%M:%SZ>
 ```
 


### PR DESCRIPTION
# Description

Started by adding a note on `.sha256.txt` to the `README`, then in the same context decided to fix some spelling, tweak white space, and fix the tag reference, as well as improving the description on the format of `_RELEASES` and adding a note on our future security-related aims (partly already mentioned in this repo's Issues).

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
