### PR TITLE
Create a pull request per version build (and auto-approve it)

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -175,8 +175,8 @@ _releases_update() {
         git commit -m "Update _RELEASES: ${global_FILENAME_NO_EXT}"
         git push origin "${release_name}"
         pr=$(gh pr create -B main -t "Automation: update _RELEASES for ${global_FILENAME_NO_EXT}")
-        gh pr review ${pr} -a
-        gh pr merge ${pr} --admin --auto
+        gh pr review "${pr}" -a
+        gh pr merge "${pr}" --admin --auto
         git switch main
     else
         echo "Skipping branch ${GITHUB_REF} (runs in main alone)"

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -105,6 +105,7 @@ kerl_configure
 echo "::endgroup::"
 
 pick_otp_vsn() {
+    git fetch --all --tags
     global_OTP_VSN=undefined
     while read -r release; do
         prepare_git_tag "${release}"

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -167,11 +167,17 @@ _releases_update() {
         echo "${global_FILENAME_NO_EXT} ${crc32} ${date}" >>_RELEASES
         sort -o _RELEASES _RELEASES
 
+        release_name="release/${global_FILENAME_NO_EXT}"
         git config user.name "GitHub Actions"
         git config user.email "actions@user.noreply.github.com"
         git add _RELEASES
+        git switch -c releases "${release_name}"
         git commit -m "Update _RELEASES: ${global_FILENAME_NO_EXT}"
-        git push origin "${GITHUB_REF_NAME}"
+        git push origin "${release_name}"
+        pr=$(gh pr create -B main -t "Automation: update _RELEASES for ${global_FILENAME_NO_EXT}")
+        gh pr review ${pr} -a
+        gh pr merge ${pr} --admin --auto
+        git switch main
     else
         echo "Skipping branch ${GITHUB_REF} (runs in main alone)"
     fi


### PR DESCRIPTION
# Description

Since we force our pull requests to be updated as per `main`, as well as forcing a pull request to exist before we merge to that branch, this seems like an Ok compromise, for the time being. All of this might just be wishful thinking, but I want:

1. an updated `_RELEASES` to use outside of this repo.
2. a tag in `main` that contains that update and allows to create the releases

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
