### PR TITLE
Fix checkout and verify tag

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -109,11 +109,9 @@ pick_otp_vsn() {
     while read -r release; do
         prepare_git_tag "${release}"
 
-        pushd "${global_INITIAL_DIR}" || exit
-        if git show-ref --tags --verify --quiet "refs/tags/${global_GIT_TAG}"; then
+        if grep "${global_GIT_TAG} " _RELEASES; then
             continue
         fi
-        popd "${global_INITIAL_DIR}" || exit
 
         global_OTP_VSN=${release}
         break

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -105,14 +105,15 @@ kerl_configure
 echo "::endgroup::"
 
 pick_otp_vsn() {
-    git fetch --all --tags
     global_OTP_VSN=undefined
     while read -r release; do
         prepare_git_tag "${release}"
 
+        pushd "${global_INITIAL_DIR}" || exit
         if git show-ref --tags --verify --quiet "refs/tags/${global_GIT_TAG}"; then
             continue
         fi
+        popd "${global_INITIAL_DIR}" || exit
 
         global_OTP_VSN=${release}
         break

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -160,7 +160,7 @@ release_prepare
 echo "::endgroup::"
 
 _releases_update() {
-    if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+    if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
         prepare_filename_no_ext "${global_OTP_VSN}"
         prepare_tar_gz_path "${global_OTP_VSN}"
 
@@ -181,7 +181,7 @@ _releases_update() {
         gh pr merge "${pr}" --admin --auto
         git switch main
     else
-        echo "Skipping branch ${GITHUB_REF} (runs in main alone)"
+        echo "Skipping branch ${GITHUB_REF_NAME} (runs in main alone)"
     fi
 }
 echo "::group::_RELEASES: update"

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -109,9 +109,11 @@ pick_otp_vsn() {
     while read -r release; do
         prepare_git_tag "${release}"
 
+        pushd "${global_INITIAL_DIR}" || exit
         if grep "${global_GIT_TAG} " _RELEASES; then
             continue
         fi
+        popd || exit
 
         global_OTP_VSN=${release}
         break

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -172,13 +172,13 @@ _releases_update() {
         release_name="release/${global_FILENAME_NO_EXT}"
         git config user.name "GitHub Actions"
         git config user.email "actions@user.noreply.github.com"
+        git switch -c "${release_name}"
         git add _RELEASES
-        git switch -c releases "${release_name}"
-        git commit -m "Update _RELEASES: ${global_FILENAME_NO_EXT}"
+        commit_msg="Update _RELEASES: add ${global_FILENAME_NO_EXT}"
+        git commit -m "${commit_msg}"
         git push origin "${release_name}"
-        pr=$(gh pr create -B main -t "Automation: update _RELEASES for ${global_FILENAME_NO_EXT}")
-        gh pr review "${pr}" -a
-        gh pr merge "${pr}" --admin --auto
+        pr=$(gh pr create -B main -t "[automation] ${commit_msg}" -b "🔒 tight, tight, tight!")
+        gh pr merge "${pr}" -s
         git switch main
     else
         echo "Skipping branch ${GITHUB_REF_NAME} (runs in main alone)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           # We want jobs to always checkout the updated branch, since we push to it, below
           ref: ${{github.ref_name}}
-          fetch-depth: 0
 
       - name: Configure and build
         timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,15 @@ jobs:
         with:
           # We want jobs to always checkout the updated branch, since we push to it, below
           ref: ${{github.ref_name}}
+          fetch-depth: 0
 
       - name: Configure and build
         timeout-minutes: 20
         id: config_build
         run: |
           ./.github/workflows/release.sh ${{matrix.macos-vsn}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac  # v4.0.0
         with:
-          # We want jobs to always checkout the updated branch, since we push to it, below
+          # We want jobs to always checkout the updated branch
           ref: ${{github.ref_name}}
 
       - name: Configure and build


### PR DESCRIPTION
# Description

We were doing `git show-ref` in the context of `kerl`'s checkout, so it'd always fail 😄 

Also, we now use GHA to create and approve the `_RELEASES` updates' pull requests:

1. creates release branch
2. updates `_RELEASES`
3. pushes `_RELEASES`
4. creates PR
5. merges PR

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
