### PR TITLE
Fix verification for existing version

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -107,7 +107,7 @@ echo "::endgroup::"
 pick_otp_vsn() {
     global_OTP_VSN=undefined
     while read -r release; do
-        if [[ $release =~ ^[0-9].*$ ]]; then
+        if [[ ${release} =~ ^[0-9].*$ ]]; then
             high=${release%%.*}
             echo "  Found latest major version to be ${high}"
             oldest_supported=$((high - 2))
@@ -117,9 +117,9 @@ pick_otp_vsn() {
     done < <(./kerl list releases all | sort -r)
 
     while read -r release; do
-        if [[ $release =~ ^[0-9].*$ ]]; then
+        if [[ ${release} =~ ^[0-9].*$ ]]; then
             major=${release%%.*}
-            if [[ $major -lt $oldest_supported ]]; then
+            if [[ ${major} -lt ${oldest_supported} ]]; then
                 continue
             fi
 

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -38,7 +38,7 @@ prepare_filename_no_ext() {
     local otp_vsn=$1
 
     # The format used for the generated filenames
-    global_FILENAME_NO_EXT=macos64-${global_MACOS_VSN}-OTP-${otp_vsn}
+    global_FILENAME_NO_EXT=macos64-${global_MACOS_VSN}_OTP-${otp_vsn}
 }
 
 prepare_filename_tar_gz() {
@@ -123,10 +123,10 @@ pick_otp_vsn() {
                 continue
             fi
 
-            prepare_git_tag "${release}"
+            prepare_filename_no_ext "${release}"
 
             pushd "${global_INITIAL_DIR}" || exit
-            if test -f _RELEASES && grep "${global_GIT_TAG} " _RELEASES; then
+            if test -f _RELEASES && grep "${global_FILENAME_NO_EXT} " _RELEASES; then
                 continue
             fi
             popd || exit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac  # v4.0.0
+        with:
+          # The previous job updates main, so we need to update it here too
+          ref: main
+        if: ${{github.ref == 'refs/heads/main'}}
+
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1
         with:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The images are built with documentation chunks as per `make docs DOC_TARGETS=chu
 
 ### Releases
 
-Releases are tagged as `macos-${macos_vsn}/OTP-${otp_vsn}`, and available at
+Releases are tagged as `macos64-${macos_vsn}/OTP-${otp_vsn}`, and available at
 <https://github.com/jelly-beam/otp-macos/releases/> under section Assets. We aim to keep naming
 of the assets consistent as to ease use in CI pipelines.
 
@@ -31,8 +31,13 @@ File `_RELEASES` will contain the available `.tar.gz` packages, as well as the e
 `crc32` on them and a date (of approximately when the build was finished), in the following format:
 
 ```plain
-<OTP-vsn> <crc32_for_tar_gz> <date_as_utc_%Y-%m-%dT%H:%M:%SZ>
+<vsn> <crc32_for_tar_gz> <date_as_utc_%Y-%m-%dT%H:%M:%SZ>
 ```
+
+where:
+
+* `vsn` (the name of the file with the build), is `macos64-${macos_vsn}_OTP-${otp_vsn}` (similar
+to the tag, but notice the `_` instead of the `/`)
 
 Finally, we also include a `.sha256.txt` in releases, for consumers to verify the origin of the
 files. To do so, run `shasum -a 256 <file>` where `<file>` is the downloaded `.tar.gz` asset,


### PR DESCRIPTION
# Description

We were looking for the tag, inside the `_RELEASES` file, when we should be looking for the filename (no ext.).

Perhaps they were the same at a point in time and this bug just slipped through the cracks.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
