### PR TITLE
Fix release and tag commit ref.(off-by-one)

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -227,6 +227,7 @@ _releases_update() {
         pr=$(gh pr create -B main -t "[automation] ${commit_msg}" -b "🔒 tight, tight, tight!")
         gh pr merge "${pr}" -s
         git switch main
+        git pull # Otherwise the pr merge commit is not picked up
     else
         echo "Skipping branch ${GITHUB_REF_NAME} (runs in main alone)"
     fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac  # v4.0.0
-        with:
-          # The previous job updates main, so we need to update it here too
-          ref: main
-        if: ${{github.ref == 'refs/heads/main'}}
-
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v1
         with:


### PR DESCRIPTION
# Description

We were off-by-one because of not pulling `main` after `pr merge`.

Also, with the fix to the script, the `yml` bit is not required anymore.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
