### PR TITLE
Use static OpenSSL linking

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,10 +4,13 @@ name: Nightly
 "on":
   schedule:
     - cron: 0 0 * * *
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     branches-ignore:
       - main
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   release:

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -124,7 +124,7 @@ kerl_configure() {
 
     export_kerl_configuration_option "--disable-dynamic-ssl-lib"
     local with_ssl
-    with_ssl="$(brew --prefix openssl@1.1)"
+    with_ssl="$(brew --prefix openssl@3.0)"
     export_kerl_configuration_option "--with-ssl=${with_ssl}"
 
     local openssl_version

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -123,8 +123,10 @@ kerl_configure() {
     export KERL_BUILD_DOCS
 
     export_kerl_configuration_option "--disable-dynamic-ssl-lib"
+    local openssl
+    openssl=$(command -v openssl)
     local with_ssl
-    with_ssl="$(command -v openssl)/../.."
+    with_ssl="$(dirname "$(dirname "${openssl}")")"
     export_kerl_configuration_option "--with-ssl=${with_ssl}"
 
     local openssl_version

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -85,6 +85,13 @@ is_nightly_otp_for() {
     fi
 }
 
+export_kerl_configuration_option() {
+    # $1: configuration option
+
+    KERL_CONFIGURE_OPTIONS="${KERL_CONFIGURE_OPTIONS:-} $1"
+    export KERL_CONFIGURE_OPTIONS
+}
+
 # Workflow groups
 
 homebrew_install() {
@@ -114,6 +121,11 @@ kerl_configure() {
 
     KERL_BUILD_DOCS=yes
     export KERL_BUILD_DOCS
+
+    export_kerl_configuration_option "--disable-dynamic-ssl-lib"
+    local with_ssl
+    with_ssl="$(command -v openssl)/../.."
+    export_kerl_configuration_option "--with-ssl=${with_ssl}"
 
     local openssl_version
     openssl_version=$(openssl version)

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -123,10 +123,8 @@ kerl_configure() {
     export KERL_BUILD_DOCS
 
     export_kerl_configuration_option "--disable-dynamic-ssl-lib"
-    local openssl
-    openssl=$(command -v openssl)
     local with_ssl
-    with_ssl="$(dirname "$(dirname "${openssl}")")"
+    with_ssl="$(brew --prefix openssl@1.1)"
     export_kerl_configuration_option "--with-ssl=${with_ssl}"
 
     local openssl_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,13 @@ name: Release
 "on":
   schedule:
     - cron: 0 */2 * * *
-  workflow_dispatch:
+  workflow_dispatch: {}
   push:
     branches-ignore:
       - main
+  pull_request:
+    branches:
+      - "*"
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ aim to stop depending on these in the future.
 
 The images are built with documentation chunks as per `make docs DOC_TARGETS=chunks`.
 
+### OpenSSL
+
+The images are built with static OpenSSL linking, via
+`--disable-dynamic-ssl-lib --with-ssl=$(command -v openssl)/../..`.
+
 ### Releases
 
 Releases are tagged as `darwin64-${macos_vsn}/OTP-${otp_vsn}`, and available at

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Find below updated information on our security policy.
 We take the security of this software seriously.
 
 We don't implement a bug bounty program or bounty rewards, but will work with
-you closed to ensure that your findings gets the appropriate handling.
+you to ensure that your findings gets the appropriate handling.
 
 ## Reporting Security Issues
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Find below updated information on our security policy.
 We take the security of this software seriously.
 
 We don't implement a bug bounty program or bounty rewards, but will work with
-you to ensure that your findings gets the appropriate handling.
+you to ensure that your findings get the appropriate handling.
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
# Description

Closes #4.

## Further considerations

ℹ️ I wouldn't mind downloading and compiling OpenSSL, but wouldn't that mean we'd have to have a matrix for "OpenSSL vsn to darwin vsn"? Or should we just go with 1.1 for now and care about that later?

⚠️ I'm gonna go over https://github.com/erlang/otp/issues/4389 with open 👀 and (potentially) update our code as per [Sverker's suggestion](https://github.com/erlang/otp/issues/4389#issuecomment-776587286). @starbelly, do you know if `--disable-dynamic-ssl-lib` is honoured these days, though, and configuration doesn't fall back to dynamic linking if static fails?

## Findings as per OTP release notes

- 24.0 added /usr/local/opt/openssl to the openssl configure search path
  - this helps us some
- 24.0 has configure scripts in crypto and erts ... fail if a requested feature cannot be enabled... It is now better at finding usable OpenSSL libraries
  - we need to find out if this also means that requesting dynamic ssl lib to be disabled also fails in case static linking is not possible (at a point in time it'd fall back to dynamic linking, even if explicitly disabled)
- 24.2 states the crypto app in OTP can now be compiled, linked and used with the new OpenSSL 3.0 cryptolib, (though) this release (is) *not recommended* for other usages than experiments and alpha testing
  - no requirement for change here, for us, just history
- 25.1 states Crypto is now considered to be usable with the OpenSSL 3.0 cryptolib for production code
  - this means that if we're to have a openssl vs. otp matrix we can start linking to 3.0 from 25.1 on

## Further considerations

To move this pull request forward we need to think about:

1. adding a test like https://github.com/jelly-beam/otp-macos/pull/89#issuecomment-1742231421
2. having an issue to notify us in case of failed builds
3. https://github.com/jelly-beam/otp-macos/pull/89#issuecomment-1744200210
4. moving our lowest target to 25.1 (to go for OpenSSL 3.x)

Once the pull request is merged (or prior to that):

1. remove all tags
2. remove all releases
3. remove all `[automation]` commits from the main branch

----

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
