### PR TITLE
Output build log

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -201,12 +201,15 @@ pick_otp_vsn() {
         exit 0
     fi
 }
+pick_non_nightly_otp_vsn() {
+    global_IS_NIGHTLY_OTP=$(is_nightly_otp_for "${global_OTP_VSN}")
+    if [[ ${global_IS_NIGHTLY_OTP} == false ]]; then
+        pick_otp_vsn
+    fi
+}
 echo "::group::Erlang/OTP: pick version to build"
 cd_kerl_dir
-global_IS_NIGHTLY_OTP=$(is_nightly_otp_for "${global_OTP_VSN}")
-if [[ ${global_IS_NIGHTLY_OTP} == false ]]; then
-    pick_otp_vsn
-fi
+pick_non_nightly_otp_vsn
 echo "Picked OTP ${global_OTP_VSN}"
 echo "::endgroup::"
 
@@ -222,6 +225,13 @@ kerl_build_install() {
 echo "::group::kerl: build-install"
 cd_kerl_dir
 kerl_build_install "${global_OTP_VSN}"
+echo "::endgroup::"
+
+kerl_build_log() {
+    cat ~/.kerl/builds/"${global_OTP_VSN}"/otp_build_"${global_OTP_VSN}".log
+}
+echo "::group::kerl: build log"
+kerl_build_log
 echo "::endgroup::"
 
 erl_test() {


### PR DESCRIPTION
# Description

I'm creating this as a draft for testing purposes, but it's possible it becomes required to merge. My thinking is that if build fails it should not be possible to check the output log, because the action would exit with `1`, but it seems it doesn't, so I might be missing a detail.

Closes #&lt;issue&gt;.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
