### PR TITLE
Remove macOS 12 from build pipelines

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        darwin-vsn: ["12", "13", "14"]
+        darwin-vsn: ["13", "14"]
         otp-vsn: ["master", "maint"]  # The same as is_nightly_otp_for, in release.sh
         arch: ["x64"]
       fail-fast: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        darwin-vsn: ["12", "13", "14"]
+        darwin-vsn: ["13", "14"]
         arch: ["x64"]
       fail-fast: true
       max-parallel: 1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 It was initially created to support macOS on <https://github.com/erlef/setup-beam> builds.
 
 We aim to build all Erlang versions (at most one every 2 hours - for all OS versions) starting from
-Erlang/OTP 25.1, and targeting macOS for the versions supported by GitHub Actions (12, 13, and 14
+Erlang/OTP 25.1, and targeting macOS for the versions supported by GitHub Actions (13, and 14
 at the time of this writing).
 
 We also aim to build from `master` and `maint`, nightly, mostly to allow consumers to be on the


### PR DESCRIPTION
# Description

I'm acting on GitHub Actions' output:

```
You are using macOS 12.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
