### PR TITLE
Exit with error when static linking fails

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -244,7 +244,7 @@ erl_test() {
     if [[ ${dyn} -ne "" ]]; then
         echo "OpenSSL linking not static! Exiting..."
         echo "::endgroup::"
-        exit 0
+        exit 1
     fi
 }
 echo "::group::erl: test build result"


### PR DESCRIPTION
# Description

As per PR title, we `exit 1`.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
