### PR TITLE
Use composite actions to simplify maintenance

### DIFF
--- a/.github/actions/build-and-release/action.yml
+++ b/.github/actions/build-and-release/action.yml
@@ -3,8 +3,6 @@ name: "Build and release"
 description: "Build and release on identified inputs"
 
 inputs:
-  head_ref:
-    required: true
   darwin-vsn:
     required: true
   otp-vsn:

--- a/.github/actions/build-and-release/action.yml
+++ b/.github/actions/build-and-release/action.yml
@@ -20,6 +20,7 @@ runs:
           ./.github/workflows/release.sh ${{inputs.darwin-vsn}} ${{inputs.otp-vsn}}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        shell: bash
 
       - name: Release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8

--- a/.github/actions/build-and-release/action.yml
+++ b/.github/actions/build-and-release/action.yml
@@ -1,0 +1,49 @@
+---
+name: "Build and release"
+description: "Build and release on identified inputs"
+
+inputs:
+  head_ref:
+    required: true
+  darwin-vsn:
+    required: true
+  otp-vsn:
+    default: undefined
+
+runs:
+  using: "composite"
+  steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          # We want jobs to always checkout the updated branch
+          ref: ${{inputs.head_ref}}
+
+      - name: Configure and build
+        timeout-minutes: 60
+        id: config_build
+        run: |
+          ./.github/workflows/release.sh ${{inputs.darwin-vsn}} ${{inputs.otp-vsn}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+        with:
+          body: >
+            This is
+            Erlang/OTP ${{steps.config_build.outputs.otp_vsn}} compiled for
+            Darwin ${{inputs.darwin-vsn}} (64 bit).
+          files: |
+            ${{steps.config_build.outputs.tar_gz}}
+            ${{steps.config_build.outputs.sha256_txt}}
+          tag_name: ${{steps.config_build.outputs.git_tag}}
+          target_commitish: ${{steps.config_build.outputs.target_commitish}}
+        if: "${{github.ref == 'refs/heads/main' &&
+             steps.config_build.outputs.target_commitish != ''}}"
+
+      - name: Notify on failed build
+        uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
+        if: failure() && github.ref == 'refs/heads/main'
+        id: failed-build
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/actions/build-and-release/action.yml
+++ b/.github/actions/build-and-release/action.yml
@@ -13,11 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
-        with:
-          # We want jobs to always checkout the updated branch
-          ref: ${{inputs.head_ref}}
-
       - name: Configure and build
         timeout-minutes: 60
         id: config_build

--- a/.github/actions/build-and-release/action.yml
+++ b/.github/actions/build-and-release/action.yml
@@ -9,37 +9,38 @@ inputs:
     required: true
   otp-vsn:
     default: undefined
+  github-token:
+    required: true
 
 runs:
   using: "composite"
   steps:
-      - name: Configure and build
-        timeout-minutes: 60
-        id: config_build
-        run: |
-          ./.github/workflows/release.sh ${{inputs.darwin-vsn}} ${{inputs.otp-vsn}}
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        shell: bash
+    - name: Configure and build
+      id: config_build
+      run: |
+        ./.github/workflows/release.sh ${{inputs.darwin-vsn}} ${{inputs.otp-vsn}}
+      env:
+        GITHUB_TOKEN: ${{inputs.github-token}}
+      shell: bash
 
-      - name: Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
-        with:
-          body: >
-            This is
-            Erlang/OTP ${{steps.config_build.outputs.otp_vsn}} compiled for
-            Darwin ${{inputs.darwin-vsn}} (64 bit).
-          files: |
-            ${{steps.config_build.outputs.tar_gz}}
-            ${{steps.config_build.outputs.sha256_txt}}
-          tag_name: ${{steps.config_build.outputs.git_tag}}
-          target_commitish: ${{steps.config_build.outputs.target_commitish}}
-        if: "${{github.ref == 'refs/heads/main' &&
-             steps.config_build.outputs.target_commitish != ''}}"
+    - name: Release
+      uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+      with:
+        body: >
+          This is
+          Erlang/OTP ${{steps.config_build.outputs.otp_vsn}} compiled for
+          Darwin ${{inputs.darwin-vsn}} (64 bit).
+        files: |
+          ${{steps.config_build.outputs.tar_gz}}
+          ${{steps.config_build.outputs.sha256_txt}}
+        tag_name: ${{steps.config_build.outputs.git_tag}}
+        target_commitish: ${{steps.config_build.outputs.target_commitish}}
+      if: "${{github.ref == 'refs/heads/main' &&
+           steps.config_build.outputs.target_commitish != ''}}"
 
-      - name: Notify on failed build
-        uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
-        if: failure() && github.ref == 'refs/heads/main'
-        id: failed-build
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+    - name: Notify on failed build
+      uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
+      if: failure() && github.ref == 'refs/heads/main'
+      id: failed-build
+      with:
+        github-token: ${{inputs.github-token}}

--- a/.github/actions/get-branch/action.yml
+++ b/.github/actions/get-branch/action.yml
@@ -1,0 +1,17 @@
+---
+name: "Get branch"
+description: "Get the name of the branch running the action"
+
+outputs:
+  head_ref:
+    value: ${{steps.branch.outputs.head_ref}}
+
+runs:
+  using: "composite"
+  steps:
+    - id: branch
+      run: |
+        head_ref=${GITHUB_REF}
+        echo "head_ref is ${head_ref}"
+        [[ -z "${head_ref}" ]] && exit 1
+        echo "head_ref=${head_ref}" > "${GITHUB_OUTPUT}"

--- a/.github/actions/get-branch/action.yml
+++ b/.github/actions/get-branch/action.yml
@@ -15,3 +15,4 @@ runs:
         echo "head_ref is ${head_ref}"
         [[ -z "${head_ref}" ]] && exit 1
         echo "head_ref=${head_ref}" > "${GITHUB_OUTPUT}"
+      shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,8 +34,10 @@ jobs:
         uses: ./.github/actions/get-branch
 
       - name: Build and release
+        timeout-minutes: 60
         uses: ./.github/actions/build-and-release
         with:
           head_ref: ${{steps.branch.outputs.head_ref}}
           darwin-vsn: ${{matrix.darwin-vsn}}
           otp-vsn: ${{matrix.otp-vsn}}
+          github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,24 +11,8 @@ name: Nightly
       - synchronize
 
 jobs:
-  branch:
-    outputs:
-      head_ref: ${{steps.branch.outputs.head_ref}}
-
-    runs-on: ubuntu-24.04
-
-    steps:
-      - id: branch
-        run: |
-          head_ref=${GITHUB_REF}
-          echo "head_ref is ${head_ref}"
-          [[ -z "${head_ref}" ]] && exit 1
-          echo "head_ref=${head_ref}" > "${GITHUB_OUTPUT}"
-
   release:
     name: Nightly
-
-    needs: [branch]
 
     strategy:
       matrix:
@@ -40,37 +24,13 @@ jobs:
     runs-on: macos-${{matrix.darwin-vsn}}
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
-        with:
-          # We want jobs to always checkout the updated branch
-          ref: ${{needs.branch.outputs.head_ref}}
+      - name: Get branch
+        id: branch
+        uses: ./.github/actions/get-branch
 
-      - name: Configure and build
-        timeout-minutes: 60
-        id: config_build
-        run: |
-          ./.github/workflows/release.sh ${{matrix.darwin-vsn}} ${{matrix.otp-vsn}}
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+      - name: Build and release
+        uses: ./.github/actions/build-and-release
         with:
-          body: >
-            This is
-            Erlang/OTP ${{steps.config_build.outputs.otp_vsn}} compiled for
-            Darwin ${{matrix.darwin-vsn}} (64 bit).
-          files: |
-            ${{steps.config_build.outputs.tar_gz}}
-            ${{steps.config_build.outputs.sha256_txt}}
-          tag_name: ${{steps.config_build.outputs.git_tag}}
-          target_commitish: ${{steps.config_build.outputs.target_commitish}}
-        if: "${{github.ref == 'refs/heads/main' &&
-             steps.config_build.outputs.target_commitish != ''}}"
-
-      - name: Notify on failed build
-        uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
-        if: failure() && github.ref == 'refs/heads/main'
-        id: failed-build
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          head_ref: ${{steps.branch.outputs.head_ref}}
+          darwin-vsn: ${{matrix.darwin-vsn}}
+          otp-vsn: ${{matrix.otp-vsn}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,8 +11,22 @@ name: Nightly
       - synchronize
 
 jobs:
+  branch:
+    outputs:
+      head_ref: ${{steps.branch.outputs.head_ref}}
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+
+      - id: branch
+        uses: ./.github/actions/get-branch
+
   release:
     name: Nightly
+
+    needs: [branch]
 
     strategy:
       matrix:
@@ -27,17 +41,12 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           # We want jobs to always checkout the updated branch
-          ref: ${{inputs.head_ref}}
-
-      - name: Get branch
-        id: branch
-        uses: ./.github/actions/get-branch
+          ref: ${{needs.branch.outputs.head_ref}}
 
       - name: Build and release
         timeout-minutes: 60
         uses: ./.github/actions/build-and-release
         with:
-          head_ref: ${{steps.branch.outputs.head_ref}}
           darwin-vsn: ${{matrix.darwin-vsn}}
           otp-vsn: ${{matrix.otp-vsn}}
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: macos-${{matrix.darwin-vsn}}
 
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          # We want jobs to always checkout the updated branch
+          ref: ${{inputs.head_ref}}
+
       - name: Get branch
         id: branch
         uses: ./.github/actions/get-branch

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -173,7 +173,7 @@ pick_otp_vsn() {
                 exit 1
             fi
 
-            if [[ ${major} -lt ${oldest_supported} ]] || { [[ ${major} -eq 25 ]] && [[ ${minor} -lt 1 ]] || [[ ${minor} -eq "" ]]; }; then
+            if [[ ${major} -lt ${oldest_supported} ]] || { [[ ${major} -eq 25 ]] && { [[ ${minor} -lt 1 ]] || [[ -z ${minor} ]]; }; }; then
                 continue
             fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,65 +11,26 @@ name: Release
       - synchronize
 
 jobs:
-  branch:
-    outputs:
-      head_ref: ${{steps.branch.outputs.head_ref}}
-
-    runs-on: ubuntu-24.04
-
-    steps:
-      - id: branch
-        run: |
-          head_ref=${GITHUB_REF}
-          echo "head_ref is ${head_ref}"
-          [[ -z "${head_ref}" ]] && exit 1
-          echo "head_ref=${head_ref}" > "${GITHUB_OUTPUT}"
-
   release:
     name: Release
-
-    needs: [branch]
 
     strategy:
       matrix:
         darwin-vsn: ["13", "14"]
+        # otp-vsn is picked later
       fail-fast: true
       max-parallel: 1
 
     runs-on: macos-${{matrix.darwin-vsn}}
 
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
-        with:
-          # We want jobs to always checkout the updated branch
-          ref: ${{needs.branch.outputs.head_ref}}
+      - name: Get branch
+        id: branch
+        uses: ./.github/actions/get-branch
 
-      - name: Configure and build
-        timeout-minutes: 60
-        id: config_build
-        run: |
-          ./.github/workflows/release.sh ${{matrix.darwin-vsn}}
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+      - name: Build and release
+        uses: ./.github/actions/build-and-release
         with:
-          body: >
-            This is
-            Erlang/OTP ${{steps.config_build.outputs.otp_vsn}} compiled for
-            Darwin ${{matrix.darwin-vsn}} (64 bit).
-          files: |
-            ${{steps.config_build.outputs.tar_gz}}
-            ${{steps.config_build.outputs.sha256_txt}}
-          tag_name: ${{steps.config_build.outputs.git_tag}}
-          target_commitish: ${{steps.config_build.outputs.target_commitish}}
-        if: "${{github.ref == 'refs/heads/main' &&
-             steps.config_build.outputs.target_commitish != ''}}"
-
-      - name: Notify on failed build
-        uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b  # v1.2.0
-        if: failure() && github.ref == 'refs/heads/main'
-        id: failed-build
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          head_ref: ${{steps.branch.outputs.head_ref}}
+          darwin-vsn: ${{matrix.darwin-vsn}}
+          # otp-vsn is picked later

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
         uses: ./.github/actions/get-branch
 
       - name: Build and release
+        timeout-minutes: 60
         uses: ./.github/actions/build-and-release
         with:
           head_ref: ${{steps.branch.outputs.head_ref}}
           darwin-vsn: ${{matrix.darwin-vsn}}
           # otp-vsn is picked later
+          github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: macos-${{matrix.darwin-vsn}}
 
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          # We want jobs to always checkout the updated branch
+          ref: ${{inputs.head_ref}}
+
       - name: Get branch
         id: branch
         uses: ./.github/actions/get-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,22 @@ name: Release
       - synchronize
 
 jobs:
+  branch:
+    outputs:
+      head_ref: ${{steps.branch.outputs.head_ref}}
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+
+      - id: branch
+        uses: ./.github/actions/get-branch
+
   release:
     name: Release
+
+    needs: [branch]
 
     strategy:
       matrix:
@@ -27,17 +41,12 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           # We want jobs to always checkout the updated branch
-          ref: ${{inputs.head_ref}}
-
-      - name: Get branch
-        id: branch
-        uses: ./.github/actions/get-branch
+          ref: ${{needs.branch.outputs.head_ref}}
 
       - name: Build and release
         timeout-minutes: 60
         uses: ./.github/actions/build-and-release
         with:
-          head_ref: ${{steps.branch.outputs.head_ref}}
           darwin-vsn: ${{matrix.darwin-vsn}}
           # otp-vsn is picked later
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# Description

As per the title.

⚠️ this also fixes the "comparison to 25.1 as oldest supported" which I found out while testing in GitHub. Once merged this'll start creating `-rc` versions also 😄 and hopefully by tomorrow it'll have reached 27.0.1

Closes #360.

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
