### PR TITLE
Bypass (same as before but) for a different version 27.0-rc3 on macOS 13

### DIFF
--- a/.DONT_BUILD
+++ b/.DONT_BUILD
@@ -1,2 +1,0 @@
-darwin-x86_64-13_OTP-27.0-rc2
-darwin-x86_64-13_OTP-27.0-rc3

--- a/.DONT_BUILD
+++ b/.DONT_BUILD
@@ -1,1 +1,2 @@
 darwin-x86_64-13_OTP-27.0-rc2
+darwin-x86_64-13_OTP-27.0-rc3

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -132,6 +132,7 @@ kerl_configure() {
 
     export_kerl_configuration_option "--disable-dynamic-ssl-lib"
     local with_ssl
+    brew install coreutils
     brew install openssl@3.0
     with_ssl="$(brew --prefix openssl@3.0)"
     export_kerl_configuration_option "--with-ssl=${with_ssl}"
@@ -223,12 +224,6 @@ pick_non_nightly_otp_vsn
 echo "Picked OTP ${global_OTP_VSN}"
 echo "::endgroup::"
 
-sha256sum() {
-    local openssl_sha256
-    openssl_sha256=$(openssl sha256 "$@")
-
-    echo "${openssl_sha256}" | awk '{print $2}'
-}
 kerl_build_install() {
     # $1: OTP version
 

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -6,6 +6,13 @@ global_OTP_VSN=$2
 global_INSTALL_DIR=${RUNNER_TEMP}/otp
 global_ARCH=$(uname -m)
 
+# Maybe enable debug with GitHub
+
+if [[ "${RUNNER_DEBUG}" == "1" ]]; then
+    export PS4='+ ${LINENO}: '
+    set -x
+fi
+
 # Helper functions
 
 cd_install_dir() {

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -216,6 +216,12 @@ pick_non_nightly_otp_vsn
 echo "Picked OTP ${global_OTP_VSN}"
 echo "::endgroup::"
 
+sha256sum() {
+    local openssl_sha256
+    openssl_sha256=$(openssl sha256 "$@")
+
+    echo "${openssl_sha256}" | awk '{print $2}'
+}
 kerl_build_install() {
     # $1: OTP version
 


### PR DESCRIPTION
# Description

Title is self-explanatory.

**Edit**: actually, I think both `-rc3`'s and `-rc2`'s issues are coming from `ex_doc`'s download, so I'll try to fix that first.

In any case, I intend on leaving the `.DONT_BUILD` mechanism in place as it might be useful:

1. in the future
2. to debug stuff

- [x] I have performed a self-review of my changes
- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
