### PR TITLE
Support macOS 15

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        darwin-vsn: ["13", "14"]
+        darwin-vsn: ["13", "14", "15"]
         # The same as is_nightly_otp_for, in release.sh
         otp-vsn: ["master", "maint", "maint-25", "maint-26", "maint-27"]
       fail-fast: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        darwin-vsn: ["13", "14"]
+        darwin-vsn: ["13", "14", "15"]
 
         # otp-vsn is picked later
       fail-fast: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 It was initially created to support macOS on <https://github.com/erlef/setup-beam> builds.
 
 We aim to build all Erlang versions (at most one every 2 hours - for all OS versions) starting from
-Erlang/OTP 25.1, and targeting macOS for the versions supported by GitHub Actions (13, and 14
+Erlang/OTP 25.1, and targeting macOS for the versions supported by GitHub Actions (13, 14, and 15
 at the time of this writing).
 
 We also aim to build from `master` and `maint[-*]`, nightly, mostly to allow consumers to be on the


### PR DESCRIPTION
# Description

From [Actions: macOS 15 is now available for GitHub-hosted runners (GA)](https://github.com/github/roadmap/issues/986).

- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
