### PR TITLE
Also build for `maint-25`, `maint-26`, and `maint-27` (per our current support range)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,8 @@ jobs:
     strategy:
       matrix:
         darwin-vsn: ["13", "14"]
-        otp-vsn: ["master", "maint"]  # The same as is_nightly_otp_for, in release.sh
+        # The same as is_nightly_otp_for, in release.sh
+        otp-vsn: ["master", "maint", "maint-25", "maint-26", "maint-27"]
       fail-fast: true
       max-parallel: 1
 

--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -85,7 +85,7 @@ is_nightly_otp_for() {
     # $1: OTP version
 
     local nightly_otp_targets
-    nightly_otp_targets=("master" "maint")
+    nightly_otp_targets=("master" "maint" "maint-25" "maint-26" "maint-27")
     if [[ ${nightly_otp_targets[*]} =~ $1 ]]; then
         echo true
     else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     strategy:
       matrix:
         darwin-vsn: ["13", "14"]
+
         # otp-vsn is picked later
       fail-fast: true
       max-parallel: 1

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ We aim to build all Erlang versions (at most one every 2 hours - for all OS vers
 Erlang/OTP 25.1, and targeting macOS for the versions supported by GitHub Actions (13, and 14
 at the time of this writing).
 
-We also aim to build from `master` and `maint`, nightly, mostly to allow consumers to be on the
+We also aim to build from `master` and `maint[-*]`, nightly, mostly to allow consumers to be on the
 edge, but also to test potential upcoming issues with the image build/release pipeline. These
 versions will remain in (moving target) branches with their copy of `_RELEASES`, but won't see
 an update for their version in the main branch's `_RELEASES`.
+
+**Note**: `[-*]` is either `""` or `-<supported_version>`.
 
 ## The build/release pipeline
 


### PR DESCRIPTION
# Description

... nightly, the same as with `master` and `maint`.

Closes #461.

- [x] I have read and understood the [contributing guidelines](https://github.com/jelly-beam/otp-macos/blob/main/CONTRIBUTING.md)
